### PR TITLE
Remove Python 3.7 from GitHub Actions build matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
remove build for python 3.7

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/priyanshu-panwar/fastapi-utilities?shareId=XXXX-XXXX-XXXX-XXXX).