### PR TITLE
Update publish job to use Python 3.9

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.9']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/priyanshu-panwar/fastapi-utilities?shareId=XXXX-XXXX-XXXX-XXXX).